### PR TITLE
Adding queryParams in curl call

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -40,7 +40,8 @@ class Collection
     public function getFullList(int $batch = 200, array $queryParams = [])
     {
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $this->url . "/api/collections/" . $this->collection . "/records");
+        $getParams = !empty($queryParams) ? http_build_query($queryParams) : "";
+        curl_setopt($ch, CURLOPT_URL, $this->url . "/api/collections/" . $this->collection . "/records?".$getParams);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         if (self::$token != '') {
             $headers = array(


### PR DESCRIPTION
using http_build_query()
we can simply pass the parameters  describe in the Api doc. ex  :  $this->pb->collection('coolCollection')->getFullList(200,['filter'=> $filter]) It can be used for all other function.